### PR TITLE
Compile rapido as a library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,9 @@ ENDIF ()
 ADD_LIBRARY(picotls-core ${CORE_FILES})
 TARGET_LINK_LIBRARIES(picotls-core ${CORE_EXTRA_LIBS})
 
+ADD_LIBRARY(picotls-rapido lib/rapido.c)
+TARGET_LINK_LIBRARIES(picotls-rapido)
+
 ADD_LIBRARY(picotls-minicrypto
     ${MINICRYPTO_LIBRARY_FILES}
     lib/cifra.c


### PR DESCRIPTION
So we can compile against it from external applications

I used pictols-rapido as all lib start with that name, and because the "rapido" target would clash with the rapido client.